### PR TITLE
Fix comments prefaced with nothing but whitespace

### DIFF
--- a/Assembly x86.tmLanguage
+++ b/Assembly x86.tmLanguage
@@ -130,7 +130,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>;.*$</string>
+			<string>\s*;.*$</string>
 			<key>name</key>
 			<string>comment.assembly</string>
 		</dict>


### PR DESCRIPTION
Comments alone on a line indented with tabs or spaces were not recognized as comments. This fix allows comments such as

``` nasm
            ; We
   ; are
         ; comments too!
```

to have the correct formatting in Sublime Text 2.

Does not interfere with comments on lines prefaced with code.
